### PR TITLE
Add test for invalid integer headers.

### DIFF
--- a/test/rack/conform/headers.rb
+++ b/test/rack/conform/headers.rb
@@ -20,3 +20,11 @@ it 'can echo back headers' do
 ensure
 	response&.finish
 end
+
+it 'rejects invalid non-string headers' do
+	response = client.get("/headers", {}, body({'foo-count' => 123}))
+	
+	expect(response.status).to be == 500
+ensure
+	response&.finish
+end


### PR DESCRIPTION
When investigating https://github.com/socketry/protocol-rack/issues/2 I found that `puma` will accept integer header values. This is against the spec, but it has caused users of `puma` to create apps that are incompatible with servers that follow the spec more strictly.

Possible outcomes:

- We relax the Rack specification to convert header values `to_s` (if they are not an Array.
- We make Puma more strict and reject non-string header values.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
